### PR TITLE
Fix url on 'view page source' in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,3 +122,9 @@ latex_elements = {
 # If false, no module index is generated.
 #
 # latex_domain_indices = True
+
+html_context = {
+    "source_url_prefix": "https://github.com/cn-ws/cn-ws/tree/master/docs/",
+    "display_vcs_links": 1,
+}
+


### PR DESCRIPTION
![afbeelding](https://user-images.githubusercontent.com/34233086/207376516-51eb9969-1f12-4de0-b1d6-a1585d9a09a3.png)

Top right on every documentation page is a button 'view page source'. This PR adds a link to the github page of the source. 