### PR TITLE
Fix wrong rendering

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinx_rtd_theme
 myst-parser
-docutils=0.16
+docutils==0.16


### PR DESCRIPTION
The docs were not rendering correctly. Left is how it should be, right the way it was rendered in the container.
![afbeelding](https://user-images.githubusercontent.com/34233086/211043789-7ed33ce7-6c43-4fe8-980a-28826c39caae.png)

It was solved by setting docutils to a fixed version (see also https://github.com/readthedocs/sphinx_rtd_theme/issues/1115#issuecomment-814937111)
