### PR TITLE
docs routing algorithm /model

### DIFF
--- a/docs/inifile.rst
+++ b/docs/inifile.rst
@@ -11,7 +11,7 @@ For each input in the ``ini``-file, this overview defines:
 - NAME: the name (key) of the variable
 - DTYPE: the data type of the variable
 - DEFAULT: the default value (if available)
-- MODEL PART: the model part for which this is relevant (R = Routing model, WS = WaTEM/SEDEM, CN = Curved Number)
+- MODEL PART: the model part for which this is relevant (R = Routing algorithm, WS = WaTEM/SEDEM, CN = Curved Number)
 - REQUIREMENT: The requirement of the variable (M = mandatory, C = conditionally mandatory, O = optional)
 
 Overview

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -27,7 +27,7 @@ measures, elevation and rainfall are needed in order to use the model.
 In addition, information on sewers and ditches can be used to refine the
 model.
 
-First, a routing table is created by the :ref:`routing model <routing>` and is then used in 
+First, a routing table is created by the :ref:`routing algorithm <routing>` and is then used in
 both the :ref:`WS <WS>` and :ref:`CN <CN>` submodels. However, the use of this routing table
 varies for both the CN and WS model. In WS, the routing table is used to
 compute slopes, upstream areas and the sediment mass balance, whereas in the
@@ -50,7 +50,7 @@ run-off to scale the yearly sediment load. This is explained :ref:`here
 
 .. note::
     The CN-WS package is still being optimized to make sure the CN, WS and
-    routing model can be run separately.
+    routing algorithm can be run separately.
 
 For who is this documentation?
 ==============================


### PR DESCRIPTION
docs: change routing model to routing algorithm as this is the most used scientitif naming

 (model has distinct io, whereas an algorithm is mostly refered to the equations/rulebank)