### PR TITLE
Publish documentation using cloud runner

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -14,10 +14,10 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   publish-documentation:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/documentation'
     needs: [build-packages] 
-    runs-on: [self-hosted, linux] 
-    container: registry.fluves.net/drone/cn_ws/debian11-build
+    runs-on: ubuntu-latest
+    container: ghcr.io/watem-sedem/ci/debian11-build
     steps:
       - uses: actions/download-artifact@master
         with:

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -9,8 +9,6 @@ on:
 env:
   DEBIAN_RSYNC_TARGET: /appdata/static/apt/amd64
   DRONE_BUILD_NUMBER: ${{ github.run_number }}
-  RSYNC_USER: docs
-  RSYNC_HOST: ijzer
 jobs:
   build-packages:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Was still using deprecated fluves runner. Closes #168 